### PR TITLE
Fix homebrew-cask install error

### DIFF
--- a/lib/serverkit/resources/homebrew_cask_package.rb
+++ b/lib/serverkit/resources/homebrew_cask_package.rb
@@ -8,7 +8,7 @@ module Serverkit
 
       # @note Override
       def apply
-        run_command("brew cask install #{options} #{name}")
+        run_command("brew install --cask #{options} #{name}")
       end
 
       # @note Override

--- a/lib/serverkit/resources/homebrew_cask_package.rb
+++ b/lib/serverkit/resources/homebrew_cask_package.rb
@@ -13,7 +13,7 @@ module Serverkit
 
       # @note Override
       def check
-        check_command("brew cask list -1 | grep -E '^#{name}$'")
+        check_command("brew list --cask -1 | grep -E '^#{name}$'")
       end
 
       private


### PR DESCRIPTION
Fix the following homebrew-cask errors:

```
Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
```

```
Error: Calling brew cask list is disabled! Use brew list [--cask] instead.
```